### PR TITLE
Add setting to show or hide channel icons next to channel names

### DIFF
--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/data/local/UserPreferencesRepository.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/data/local/UserPreferencesRepository.kt
@@ -1,0 +1,32 @@
+package com.heywood8.telegramnews.data.local
+
+import android.content.SharedPreferences
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UserPreferencesRepository @Inject constructor(
+    private val prefs: SharedPreferences,
+) {
+    companion object {
+        private const val KEY_SHOW_CHANNEL_ICONS = "show_channel_icons"
+    }
+
+    val showChannelIcons: Flow<Boolean> = callbackFlow {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+            if (key == KEY_SHOW_CHANNEL_ICONS) {
+                trySend(prefs.getBoolean(KEY_SHOW_CHANNEL_ICONS, true))
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        send(prefs.getBoolean(KEY_SHOW_CHANNEL_ICONS, true))
+        awaitClose { prefs.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
+    fun setShowChannelIcons(show: Boolean) {
+        prefs.edit().putBoolean(KEY_SHOW_CHANNEL_ICONS, show).apply()
+    }
+}

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/di/PreferencesModule.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/di/PreferencesModule.kt
@@ -1,0 +1,20 @@
+package com.heywood8.telegramnews.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object PreferencesModule {
+
+    @Provides
+    @Singleton
+    fun provideSharedPreferences(@ApplicationContext context: Context): SharedPreferences =
+        context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+}

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/channels/ChannelListScreen.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/channels/ChannelListScreen.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -38,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.heywood8.telegramnews.domain.model.Subscription
+import com.heywood8.telegramnews.ui.common.ChannelIcon
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -46,6 +49,7 @@ fun ChannelListScreen(viewModel: ChannelViewModel = hiltViewModel()) {
     val searchResults by viewModel.searchResults.collectAsStateWithLifecycle()
     val searching by viewModel.searching.collectAsStateWithLifecycle()
     val selectedSub by viewModel.selectedSub.collectAsStateWithLifecycle()
+    val showChannelIcons by viewModel.showChannelIcons.collectAsStateWithLifecycle()
 
     var query by rememberSaveable { mutableStateOf("") }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -93,6 +97,10 @@ fun ChannelListScreen(viewModel: ChannelViewModel = hiltViewModel()) {
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.SpaceBetween,
                             ) {
+                                if (showChannelIcons) {
+                                    ChannelIcon(name = channel.title.ifBlank { channel.username })
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                }
                                 Column(modifier = Modifier.weight(1f)) {
                                     Text(channel.title, style = MaterialTheme.typography.bodyLarge)
                                     Text(
@@ -129,6 +137,7 @@ fun ChannelListScreen(viewModel: ChannelViewModel = hiltViewModel()) {
                         items(subscriptions, key = { it.channel }) { sub ->
                             SubscriptionItem(
                                 sub = sub,
+                                showIcon = showChannelIcons,
                                 onClick = { viewModel.selectSubscription(sub) },
                                 onDelete = { viewModel.unsubscribe(sub.channel) },
                             )
@@ -157,6 +166,7 @@ fun ChannelListScreen(viewModel: ChannelViewModel = hiltViewModel()) {
 @Composable
 private fun SubscriptionItem(
     sub: Subscription,
+    showIcon: Boolean,
     onClick: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -169,6 +179,10 @@ private fun SubscriptionItem(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
+            if (showIcon) {
+                ChannelIcon(name = sub.channel)
+                Spacer(modifier = Modifier.width(12.dp))
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Text("@${sub.channel}", style = MaterialTheme.typography.bodyLarge)
                 Text(

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/channels/ChannelViewModel.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/channels/ChannelViewModel.kt
@@ -2,6 +2,7 @@ package com.heywood8.telegramnews.ui.channels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.heywood8.telegramnews.data.local.UserPreferencesRepository
 import com.heywood8.telegramnews.domain.model.Channel
 import com.heywood8.telegramnews.domain.model.Subscription
 import com.heywood8.telegramnews.domain.repository.LocalRepository
@@ -23,7 +24,11 @@ class ChannelViewModel @Inject constructor(
     private val localRepo: LocalRepository,
     private val telegramRepo: TelegramRepository,
     private val subscriptionUseCase: SubscriptionUseCase,
+    private val userPrefs: UserPreferencesRepository,
 ) : ViewModel() {
+
+    val showChannelIcons: StateFlow<Boolean> = userPrefs.showChannelIcons
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     val subscriptions: StateFlow<List<Subscription>> = localRepo.observeSubscriptions(FeedViewModel.USER_ID)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/common/ChannelIcon.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/common/ChannelIcon.kt
@@ -1,0 +1,45 @@
+package com.heywood8.telegramnews.ui.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+private val iconColors = listOf(
+    Color(0xFF5C6BC0),
+    Color(0xFF26A69A),
+    Color(0xFFEF5350),
+    Color(0xFFAB47BC),
+    Color(0xFF42A5F5),
+    Color(0xFFFF7043),
+    Color(0xFF66BB6A),
+    Color(0xFFEC407A),
+)
+
+@Composable
+fun ChannelIcon(name: String, size: Dp = 36.dp) {
+    val initial = name.firstOrNull()?.uppercaseChar() ?: '#'
+    val color = iconColors[name.hashCode().and(0x7fffffff) % iconColors.size]
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(CircleShape)
+            .background(color),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = initial.toString(),
+            style = MaterialTheme.typography.labelLarge,
+            color = Color.White,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/feed/FeedScreen.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/feed/FeedScreen.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -37,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.heywood8.telegramnews.domain.model.Message
+import com.heywood8.telegramnews.ui.common.ChannelIcon
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -47,6 +50,7 @@ fun FeedScreen(viewModel: FeedViewModel = hiltViewModel()) {
     val messages by viewModel.filteredMessages.collectAsStateWithLifecycle()
     val subscriptions by viewModel.subscriptions.collectAsStateWithLifecycle()
     val selectedChannel by viewModel.selectedChannel.collectAsStateWithLifecycle()
+    val showChannelIcons by viewModel.showChannelIcons.collectAsStateWithLifecycle()
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
@@ -102,7 +106,7 @@ fun FeedScreen(viewModel: FeedViewModel = hiltViewModel()) {
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(messages, key = { it.id }) { message ->
-                        FeedItem(message, onClick = { selectedMessage = message })
+                        FeedItem(message, showChannelIcons, onClick = { selectedMessage = message })
                     }
                 }
             }
@@ -118,7 +122,7 @@ fun FeedScreen(viewModel: FeedViewModel = hiltViewModel()) {
 }
 
 @Composable
-private fun FeedItem(message: Message, onClick: () -> Unit) {
+private fun FeedItem(message: Message, showChannelIcons: Boolean, onClick: () -> Unit) {
     ElevatedCard(
         onClick = onClick,
         modifier = Modifier.fillMaxWidth(),
@@ -130,11 +134,22 @@ private fun FeedItem(message: Message, onClick: () -> Unit) {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(
-                    text = message.channelTitle,
-                    style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    if (showChannelIcons) {
+                        ChannelIcon(name = message.channelTitle.ifBlank { message.channel })
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                    Text(
+                        text = message.channelTitle,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
                 Text(
                     text = formatTimestamp(message.timestamp),
                     style = MaterialTheme.typography.labelSmall,

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/feed/FeedViewModel.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/feed/FeedViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.heywood8.telegramnews.data.local.dao.MessageDao
 import com.heywood8.telegramnews.data.local.entity.MessageEntity
+import com.heywood8.telegramnews.data.local.UserPreferencesRepository
 import com.heywood8.telegramnews.domain.model.Message
 import com.heywood8.telegramnews.domain.model.Subscription
 import com.heywood8.telegramnews.domain.repository.LocalRepository
@@ -31,11 +32,15 @@ class FeedViewModel @Inject constructor(
     private val telegramRepo: TelegramRepository,
     private val filterUseCase: FilterUseCase,
     private val messageDao: MessageDao,
+    private val userPrefs: UserPreferencesRepository,
 ) : ViewModel() {
 
     companion object {
         const val USER_ID = 0L
     }
+
+    val showChannelIcons: StateFlow<Boolean> = userPrefs.showChannelIcons
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
 
     val subscriptions: StateFlow<List<Subscription>> = localRepo.observeSubscriptions(USER_ID)
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/settings/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -21,11 +22,13 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
     var showLogoutDialog by remember { mutableStateOf(false) }
+    val showChannelIcons by viewModel.showChannelIcons.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = { TopAppBar(title = { Text("Settings") }) },
@@ -49,6 +52,24 @@ fun SettingsScreen(viewModel: SettingsViewModel = hiltViewModel()) {
                     TextButton(onClick = { showLogoutDialog = true }) {
                         Text("Sign out", color = MaterialTheme.colorScheme.error)
                     }
+                },
+            )
+            Divider()
+            Text(
+                "Display",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+            ListItem(
+                headlineContent = { Text("Show channel icons") },
+                supportingContent = { Text("Show a channel icon next to the channel name") },
+                modifier = Modifier.fillMaxWidth(),
+                trailingContent = {
+                    Switch(
+                        checked = showChannelIcons,
+                        onCheckedChange = { viewModel.setShowChannelIcons(it) },
+                    )
                 },
             )
             Divider()

--- a/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/com/heywood8/telegramnews/ui/settings/SettingsViewModel.kt
@@ -2,15 +2,27 @@ package com.heywood8.telegramnews.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.heywood8.telegramnews.data.local.UserPreferencesRepository
 import com.heywood8.telegramnews.domain.repository.TelegramRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val telegramRepo: TelegramRepository,
+    private val userPrefs: UserPreferencesRepository,
 ) : ViewModel() {
+
+    val showChannelIcons: StateFlow<Boolean> = userPrefs.showChannelIcons
+        .stateIn(viewModelScope, SharingStarted.Eagerly, true)
+
+    fun setShowChannelIcons(show: Boolean) {
+        userPrefs.setShowChannelIcons(show)
+    }
 
     fun logOut() {
         viewModelScope.launch {


### PR DESCRIPTION
- Add UserPreferencesRepository backed by SharedPreferences to persist the setting
- Add PreferencesModule Hilt module to provide SharedPreferences
- Add ChannelIcon composable: colored circle with channel initial letter
- Add 'Show channel icons' toggle in Settings > Display section
- Show/hide icons in FeedScreen message headers and ChannelListScreen items
- Icons use a deterministic color derived from the channel name hash

BEGIN_COMMIT_OVERRIDE
feat: toggle channel icons

END_COMMIT_OVERRIDE